### PR TITLE
Include assert to document important assumptions

### DIFF
--- a/src/main/java/jav/command/DeleteTaskCommand.java
+++ b/src/main/java/jav/command/DeleteTaskCommand.java
@@ -20,13 +20,21 @@ public class DeleteTaskCommand extends TaskCommand {
 
     @Override
     public String execute() throws InvalidParamException {
+        // Check if given an integer
+        int index = 0;
+        try {
+            index = Integer.parseInt(param);
+        } catch (NumberFormatException e) {
+            throw new InvalidParamException("Cannot delete task, given param is not num", null);   
+        }
+
         // Check if given a -ve index
-        if (Integer.parseInt(param) < 1) {
+        if (index < 1) {
             throw new InvalidParamException("Cannot delete task, given num is -ve", null);
         }
 
         // Check if given an index bigger than size of list
-        if (StorageManager.getInstance().deleteTask(Integer.parseInt(param) - 1)) {
+        if (StorageManager.getInstance().deleteTask(index - 1)) {
             return UiManager.getInstance().printDeletingTask();
         } else {
             throw new InvalidParamException("Cannot delete task, given num is out of scope", null);

--- a/src/main/java/jav/command/UpdateTaskMarkCommand.java
+++ b/src/main/java/jav/command/UpdateTaskMarkCommand.java
@@ -24,14 +24,22 @@ public class UpdateTaskMarkCommand extends TaskCommand {
     }
 
     @Override
-    public String execute() throws InvalidParamException {
+    public String execute() throws InvalidParamException {        
+        // Check if given an integer
+        int index = 0;
+        try {
+            index = Integer.parseInt(param);
+        } catch (NumberFormatException e) {
+            throw new InvalidParamException("Cannot mark/unmark task, given param is not num", null);   
+        }
+
         // Check if given a -ve index
-        if (Integer.parseInt(param) < 1) {
+        if (index < 1) {
             throw new InvalidParamException("Cannot mark/unmark task, given num is -ve", null);
         }
 
         // Check if given an index bigger than size of list
-        if (!StorageManager.getInstance().updateTask(Integer.parseInt(param) - 1, shouldMark)) {
+        if (!StorageManager.getInstance().updateTask(index - 1, shouldMark)) {
             throw new InvalidParamException("Cannot mark/unmark task, given num is out of scope", null);
         }
 

--- a/src/main/java/jav/manager/StorageManager.java
+++ b/src/main/java/jav/manager/StorageManager.java
@@ -29,7 +29,8 @@ public class StorageManager {
     public enum StorageType {
         TODO,
         DEADLINE,
-        EVENT
+        EVENT,
+        TASK
     }
 
     /**
@@ -99,7 +100,8 @@ public class StorageManager {
             case EVENT:
                 task = new Event(param, shouldMark);
                 break;
-            default:
+                default:
+                assert false : "Unexpected task type " + type;
                 task = new Task(param, shouldMark);
                 break;
             }
@@ -193,13 +195,16 @@ public class StorageManager {
      * @param typeStr string to convert.
      * @return the converted storage type.
      */
-    public StorageType stringToStorageType(String typeStr) {
+    private StorageType stringToStorageType(String typeStr) {
         if (typeStr.equals("Event")) {
             return StorageType.EVENT;
         } else if (typeStr.equals("Deadline")) {
             return StorageType.DEADLINE;
-        } else {
+        } else if (typeStr.equals("Todo")) {
             return StorageType.TODO;
+        } else {
+            assert false : "Unexpected task type " + typeStr;
+            return StorageType.TASK;
         }
     }
 

--- a/src/main/java/jav/task/Deadline.java
+++ b/src/main/java/jav/task/Deadline.java
@@ -71,8 +71,10 @@ public class Deadline extends Task {
                 s += " {" + i + " day left}";
             } else if (i == 0) {
                 s += " {TODAY}";
-            } else {
+            } else if (i < 0) {
                 s += " {ALREADY OVER}";
+            } else {
+                assert false : "Impossible condition";
             }
         }
 


### PR DESCRIPTION
Include Java's assert feature to document important assumptions that should hold at various points in the code.

The goal is to use assertions to check and document important assumptions about certain arguments.

Additionally, in the process of searching for locations to include assertions. A location where assertion could be used was found in the DeleteTaskCommand and
UpdateTaskMarkCommand classes but instead of using assertions, using exception handling is determined to be more suitable.